### PR TITLE
Allow rolling monster hits and damages

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "diffEditor.wordWrap": "on",
   "vetur.format.enable": false,
+  "editor.formatOnSave": true,
 }

--- a/cypress/integration/combat.spec.js
+++ b/cypress/integration/combat.spec.js
@@ -7,6 +7,8 @@ describe('Combat', () => {
     cy.get('button.encounter-start-button').click()
     cy.get('.combat-overlay').should('be.visible')
     cy.get('.initiative:contains(Maukka) input').clear().type('10')
+    cy.get('.initiative:contains(Swashbuckler of Long Name Islands) input').clear().type('9')
+    cy.get('.initiative:contains(Commoner) input').clear().type('8')
     cy.get('.combat-initialization-start-combat-button').click()
   })
   it('should open and close', () => {
@@ -65,5 +67,17 @@ describe('Combat', () => {
     cy.get('.combat-grid .combat-ally').should('not.exist')
     cy.get('.combat-turn-order .combat-ally').should('not.exist')
     cy.get('.combat-unit-details').should('not.exist')
+  })
+
+  it('should roll for monster hit and damage', () => {
+    cy.get('.combat-turn-order > :nth-child(9) > .combat-unit > span').click()
+    cy.get('.combat-unit-details .monster-action').trigger('mouseenter')
+    cy.get('.combat-unit-details .monster-action > .hit-mask').should('be.visible')
+    cy.get('.combat-unit-details .monster-action > .damage-mask').should('be.visible')
+    cy.get('.combat-unit-details .monster-action > .hit-mask').click()
+    cy.get('.dice-overlay .dice-record:nth-child(1)').contains('To hit with Club')
+    cy.get('.combat-unit-details .monster-action > .damage-mask').click()
+    cy.get('.dice-overlay .dice-record:nth-child(1)').contains('Club damage')
+    cy.get('.dice-overlay .dice-record:nth-child(2)').contains('To hit with Club')
   })
 })

--- a/src/components/CombatOverlay.vue
+++ b/src/components/CombatOverlay.vue
@@ -69,6 +69,7 @@ export default {
 .combat-overlay-content {
   display: flex;
   flex-flow: column nowrap;
+  overflow: auto;
   position: fixed;
   right: 5rem;
   top: 1rem;
@@ -84,7 +85,7 @@ export default {
 }
 .board-container {
   position: relative;
-  max-height: 80%;
+  max-height: 95%;
   display: flex;
   flex-flow: row nowrap;
   overflow: auto;

--- a/src/components/CombatOverlay.vue
+++ b/src/components/CombatOverlay.vue
@@ -71,9 +71,9 @@ export default {
   flex-flow: column nowrap;
   overflow: auto;
   position: fixed;
-  right: 5rem;
+  right: 1rem;
   top: 1rem;
-  width: calc(100% - 10rem);
+  width: calc(100% - 2rem);
   height: calc(100% - 2rem);
   z-index: 1;
   display: flex;

--- a/src/components/CombatUnitDetails.vue
+++ b/src/components/CombatUnitDetails.vue
@@ -11,7 +11,7 @@
     <button class="close-button" title="Remove selection" @click="updateUnit({ ...unit, selected: false })">
       X
     </button>
-    <span>{{ unit.unitType }}</span>
+    <span>{{ unit.name }} ({{ unit.unitType }})</span>
     <div class="unit-hit-points">
       <input
         v-model="unit.hitPoints"
@@ -27,7 +27,7 @@
     <button v-if="isHorde(unit)" class="unit-split-horde-button" @click="splitHorde(unit.id)">
       Split Horde
     </button>
-    <Monster class="unit-monster" v-bind="unit.monster" />
+    <Monster v-show="unit.hovered" class="unit-monster" v-bind="unit.monster" />
   </div>
 </template>
 
@@ -118,5 +118,6 @@ export default {
   width: 1.25rem;
   height: 1.25rem;
   border: 2px solid black;
+  margin-left: 0.5rem;
 }
 </style>

--- a/src/components/CombatUnitDetails.vue
+++ b/src/components/CombatUnitDetails.vue
@@ -7,13 +7,11 @@
     @mouseover="updateUnit({ ...unit, hovered: true })"
     @mouseleave="updateUnit({ ...unit, hovered: false })"
   >
-    <turn-indicator v-show="unitIdInTurn !== unit.id" :class="{ on: true }" />
+    <turn-indicator :class="{ on: unitIdInTurn === unit.id }" />
     <button class="close-button" title="Remove selection" @click="updateUnit({ ...unit, selected: false })">
       X
     </button>
-    <div @mouseover="hover = true" @mouseleave="hover = false">
-      <span>{{ unit.name }} ({{ unit.unitType }})</span>
-    </div>
+    <span>{{ unit.unitType }}</span>
     <div class="unit-hit-points">
       <input
         v-model="unit.hitPoints"
@@ -24,12 +22,12 @@
       />
       / {{ unit.maxHitPoints }}
     </div>
-    <div v-if="hover" class="unit-tooltip"><monster id="" v-bind="unit.monster" /></div>
     <div class="color-marker" :style="{ backgroundColor: unit.color }" />
     <condition-menu class="unit-conditions" :creature="unit" />
     <button v-if="isHorde(unit)" class="unit-split-horde-button" @click="splitHorde(unit.id)">
       Split Horde
     </button>
+    <Monster class="unit-monster" v-bind="unit.monster" />
   </div>
 </template>
 
@@ -37,11 +35,13 @@
 import { mapActions, mapState } from 'vuex'
 import ConditionMenu from './ConditionMenu.vue'
 import TurnIndicator from './TurnIndicator.vue'
+import Monster from './Monster.vue'
 import { isHorde } from '../stores/combat.store'
 export default {
   name: 'CombatUnitDetails',
   components: {
     ConditionMenu,
+    Monster,
     TurnIndicator,
   },
   props: {
@@ -49,11 +49,6 @@ export default {
       type: Object,
       required: true,
     },
-  },
-  data() {
-    return {
-      hover: false,
-    }
   },
   computed: {
     ...mapState({
@@ -74,7 +69,7 @@ export default {
   width: 100%;
   padding: 0.25rem;
   grid-template-columns: 1rem 2rem 10rem 1fr;
-  grid-template-rows: auto 1fr 1fr;
+  grid-template-rows: auto auto auto;
   align-items: center;
   justify-items: flex-start;
   border: 2px solid transparent;
@@ -103,16 +98,11 @@ export default {
   font-size: 0.75rem;
   padding: 0;
 }
-.unit-tooltip {
-  position: absolute;
-  top: 1rem;
-  left: 0;
-  min-width: 25rem;
-  max-width: 40rem;
-  z-index: 3;
+.unit-monster {
+  grid-column: 1 / span 4;
 }
 .unit-conditions {
-  grid-column: 1 / span 4;
+  grid-column: 2 / span 4;
   justify-self: flex-end;
   margin-top: 0.25rem;
 }

--- a/src/components/CombatUnitDetails.vue
+++ b/src/components/CombatUnitDetails.vue
@@ -4,8 +4,8 @@
     :style="{
       border: unit.hovered ? '2px dashed black' : undefined,
     }"
-    @mouseover="updateUnit({ ...unit, hovered: true })"
-    @mouseleave="updateUnit({ ...unit, hovered: false })"
+    @mouseover="onMouseOver"
+    @mouseleave="onMouseLeave"
   >
     <turn-indicator :class="{ on: unitIdInTurn === unit.id }" />
     <button class="close-button" title="Remove selection" @click="updateUnit({ ...unit, selected: false })">
@@ -27,7 +27,7 @@
     <button v-if="isHorde(unit)" class="unit-split-horde-button" @click="splitHorde(unit.id)">
       Split Horde
     </button>
-    <Monster v-show="unit.hovered" class="unit-monster" v-bind="unit.monster" />
+    <Monster v-show="isDetailHovered" class="unit-monster" v-bind="unit.monster" />
   </div>
 </template>
 
@@ -50,6 +50,11 @@ export default {
       required: true,
     },
   },
+  data() {
+    return {
+      isDetailHovered: false,
+    }
+  },
   computed: {
     ...mapState({
       unitIdInTurn: state => state.combat.unitIdInTurn,
@@ -58,6 +63,14 @@ export default {
   methods: {
     ...mapActions('combat', ['updateUnit', 'splitHorde']),
     isHorde,
+    onMouseOver() {
+      this.updateUnit({ ...this.unit, hovered: true })
+      this.isDetailHovered = true
+    },
+    onMouseLeave() {
+      this.updateUnit({ ...this.unit, hovered: false })
+      this.isDetailHovered = false
+    },
   },
 }
 </script>

--- a/src/components/DiceOverlay.vue
+++ b/src/components/DiceOverlay.vue
@@ -7,12 +7,13 @@
         background: `url(${backgroundImage})`,
       }"
     >
-      <span class="dice-record dice-last"
-        >{{ last.result }} {{ last && last.dice && last.dice.toString(false) }}</span
-      >
-      <span v-for="record in history.slice(1)" :key="record.id" class="dice-record"
-        >{{ record.result }} {{ record.dice.toString(false) }}</span
-      >
+      <span v-for="record in history" :key="record.id" class="dice-record">
+        <span class="dice-record-result">{{ record.result }}</span>
+        <span class="dice-record-dice">({{ record.dice.toString(false) }})</span>
+        <span v-if="record.description" class="dice-record-description">
+          {{ record.description }}
+        </span>
+      </span>
     </div>
     <input
       class="dice-overlay-throws"
@@ -40,8 +41,7 @@ export default {
   },
   computed: {
     ...mapState({
-      last: state => state.ui.dice?.last ?? {},
-      history: state => state.ui.dice.history.slice(0, 10),
+      history: state => state.ui.dice.history,
       throws: state => state.ui.dice.throws,
     }),
   },
@@ -63,22 +63,35 @@ export default {
 .dice-history {
   display: flex;
   flex-flow: column;
-  justify-content: flex-end;
+  justify-content: flex-start;
   position: fixed;
   overflow-y: auto;
   bottom: 2.5rem;
   left: 0.5rem;
-  max-height: 20rem;
-  width: 7em;
+  max-height: 15rem;
   padding: 1rem;
   border-radius: 10px;
   border: 1px solid #c9ad6a;
   box-shadow: 0.1rem 0.2rem 0.2rem rgba(0, 0, 0, 0.3);
 }
 .dice-record {
-  padding: 0 0.25rem;
+  padding: 0 0 0 0.25rem;
+  display: inline-flex;
+  align-items: center;
 }
-.dice-last {
+.dice-record-result {
   font-weight: bold;
+  margin-right: 0.25rem;
+  font-size: 1.25rem;
+}
+.dice-record-dice {
+  margin-right: 0.5rem;
+}
+.dice-record-description {
+  margin-left: auto;
+  font-size: 1rem;
+  font-weight: lighter;
+  font-weight: bold;
+  font-style: italic;
 }
 </style>

--- a/src/components/MonsterAction.vue
+++ b/src/components/MonsterAction.vue
@@ -1,12 +1,21 @@
 <template>
-  <div
-    class="monster-action"
-    :role="rollable ? 'button' : ''"
-    @mouseenter="isHovered = true"
-    @mouseleave="isHovered = false"
-    @click="roll"
-  >
-    <div v-show="rollable && isHovered" class="rollable-mask">Roll</div>
+  <div class="monster-action" @mouseenter="isHovered = true" @mouseleave="isHovered = false">
+    <div
+      v-show="canHit && isHovered"
+      class="rollable-mask hit-mask"
+      :role="canHit ? 'button' : ''"
+      @click="rollHit"
+    >
+      Roll hit
+    </div>
+    <div
+      v-show="hasDamage && isHovered"
+      class="rollable-mask damage-mask"
+      :role="hasDamage ? 'button' : ''"
+      @click="rollDamage"
+    >
+      Roll damage
+    </div>
     <span class="monster-action-description">
       <span class="monster-action-name">{{ name }}.</span>
       {{ descriptionStr }}
@@ -80,15 +89,20 @@ export default {
       const hitStr = ` Hit: ${this.damage.toString()} ${this.damageType} damage`
       return `${attackTypeStr}${toHitStr}${reachRangeStr}${hitStr}. ${this.extra ?? ''}`
     },
-    rollable() {
-      return this.toHit > 0 || this.damage
+    canHit() {
+      return this.toHit !== undefined
+    },
+    hasDamage() {
+      return this.damage
     },
   },
   methods: {
     ...mapActions('ui', ['throwDice']),
-    roll() {
+    rollHit() {
       this.throwDice({ throws: 1, sides: 20, constant: this.toHit, description: `To hit with ${this.name}` })
-      this.throwDice({ ...this.damage, description: this.name })
+    },
+    rollDamage() {
+      this.throwDice({ ...this.damage, description: `${this.name} damage` })
     },
   },
 }
@@ -104,17 +118,29 @@ export default {
 .rollable-mask {
   cursor: pointer;
   box-sizing: border-box;
-  position: absolute;
-  top: 0;
-  left: 0;
-  height: 100%;
-  width: 100%;
   background: rgba(0, 0, 0, 0.4);
   color: white;
   display: flex;
   align-items: center;
   justify-content: center;
   border-radius: 2px;
+}
+.rollable-mask:hover {
+  background: rgba(0, 0, 0, 0.6);
+}
+.hit-mask {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 50%;
+}
+.damage-mask {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  height: 100%;
+  width: 50%;
 }
 .monster-action-name {
   font-weight: bold;

--- a/src/components/MonsterAction.vue
+++ b/src/components/MonsterAction.vue
@@ -1,5 +1,12 @@
 <template>
-  <div class="monster-action">
+  <div
+    class="monster-action"
+    :role="rollable ? 'button' : ''"
+    @mouseenter="isHovered = true"
+    @mouseleave="isHovered = false"
+    @click="roll"
+  >
+    <div v-show="rollable && isHovered" class="rollable-mask">Roll</div>
     <span class="monster-action-description">
       <span class="monster-action-name">{{ name }}.</span>
       {{ descriptionStr }}
@@ -9,6 +16,7 @@
 
 <script>
 import Dice from '../Dice'
+import { mapActions } from 'vuex'
 export default {
   name: 'MonsterAction',
   props: {
@@ -44,6 +52,11 @@ export default {
       type: String,
     },
   },
+  data() {
+    return {
+      isHovered: false,
+    }
+  },
   computed: {
     descriptionStr() {
       if (this.description) {
@@ -67,15 +80,41 @@ export default {
       const hitStr = ` Hit: ${this.damage.toString()} ${this.damageType} damage`
       return `${attackTypeStr}${toHitStr}${reachRangeStr}${hitStr}. ${this.extra ?? ''}`
     },
+    rollable() {
+      return this.toHit > 0 || this.damage
+    },
+  },
+  methods: {
+    ...mapActions('ui', ['throwDice']),
+    roll() {
+      this.throwDice({ throws: 1, sides: 20, constant: this.toHit, description: `To hit with ${this.name}` })
+      this.throwDice({ ...this.damage, description: this.name })
+    },
   },
 }
 </script>
 
 <style scoped>
 .monster-action {
+  position: relative;
   text-indent: 0;
   display: flex;
   flex-flow: row nowrap;
+}
+.rollable-mask {
+  cursor: pointer;
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  background: rgba(0, 0, 0, 0.4);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 2px;
 }
 .monster-action-name {
   font-weight: bold;

--- a/src/stores/ui.store.js
+++ b/src/stores/ui.store.js
@@ -32,9 +32,9 @@ export default {
     setIsCombatOverlayOpen(state, isCombatOverlayOpen) {
       state.isCombatOverlayOpen = isCombatOverlayOpen
     },
-    throwDice(state, { throws, sides, constant }) {
+    throwDice(state, { throws, sides, constant, description = '' }) {
       const dice = new Dice(throws, sides, constant)
-      state.dice.last = { dice, result: dice.throw(), id: getUniqueId() }
+      state.dice.last = { dice, result: dice.throw(), id: getUniqueId(), description }
       state.dice.history.unshift(state.dice.last)
     },
     setThrows(state, throws) {


### PR DESCRIPTION
- Roll MonsterAction's to hit and damage when MonsterAction is clicked
- Fix CombatOverlay scaling
- Fit Monster into CombatOverlay
- Finish monster hit and dmg rolling. Add tests
- Don't show monster if unit cell is hovered
